### PR TITLE
Fix Warrior Armor

### DIFF
--- a/src/data/baseUnits.ts
+++ b/src/data/baseUnits.ts
@@ -318,8 +318,8 @@ const createWarriors = (
       shooting: {
         None: 4,
         Bow: 4,
+        HeavyWeapon: 4,
         Crossbow: 3,
-        HeavyWeapon: 3,
         MountedAnimal: 3,
         Flying: 3,
         MountedAnimalCompositeBow: 3,


### PR DESCRIPTION
Fixing the shooting armor since the Heavy Weapon only reduces the melee armor, according to the rulebook.